### PR TITLE
fix(sv): enter negative number in secondsPer100vh and startTime fields

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -20,7 +20,7 @@
     "@keystone-6/core": "5.2.0",
     "@story-telling-reporter/draft-editor": "^2.1.0",
     "@story-telling-reporter/react-embed-code-generator": "^2.1.0",
-    "@story-telling-reporter/react-scrollable-video": "^2.2.0",
+    "@story-telling-reporter/react-scrollable-video": "^2.2.4",
     "@story-telling-reporter/react-three-story-controls": "^1.0.0-beta.2",
     "@types/clean-css": "^4.2.11",
     "@types/react-beautiful-dnd": "^13.1.4",

--- a/packages/scrollable-video/package.json
+++ b/packages/scrollable-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-scrollable-video",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/scrollable-video/src/cms-editor/input.tsx
+++ b/packages/scrollable-video/src/cms-editor/input.tsx
@@ -135,16 +135,19 @@ export function CaptionInput({
           <MarginTop />
           <FieldLabel>字幕出現秒數</FieldLabel>
           <TextInput
-            onChange={(e) =>
-              setInputValueState((prevState) => {
-                return Object.assign({}, prevState, {
-                  startTime: Number(e.target.value),
+            onChange={(e) => {
+              const value = parseFloat(e.target.value)
+              if (!isNaN(value)) {
+                setInputValueState((prevState) => {
+                  return Object.assign({}, prevState, {
+                    startTime: value,
+                  })
                 })
-              })
-            }
-            placeholder="0"
+              }
+            }}
             type="number"
-            value={inputValueState.startTime.toString()}
+            step="0.001"
+            defaultValue={inputValueState.startTime}
           />
           <MarginTop />
           <FieldLabel>字幕出現位置</FieldLabel>
@@ -326,16 +329,19 @@ export function ConfigInput({
       <MarginTop />
       <FieldLabel>每滑一個視窗的高度對應影片多少秒鐘</FieldLabel>
       <TextInput
-        onChange={(e) =>
-          onChange(
-            Object.assign({}, inputValue, {
-              secondsPer100vh: Number(e.target.value),
-            })
-          )
-        }
-        placeholder="0"
+        onChange={(e) => {
+          const value = parseFloat(e.target.value)
+          if (!isNaN(value)) {
+            onChange(
+              Object.assign({}, inputValue, {
+                secondsPer100vh: value,
+              })
+            )
+          }
+        }}
         type="number"
-        value={inputValue?.secondsPer100vh?.toString()}
+        step="0.001"
+        defaultValue={inputValue?.secondsPer100vh?.toString()}
       />
     </>
   )


### PR DESCRIPTION
### Bug 描述
捲動式影片編輯器裡，「每滑一個視窗的高度對應影片多少秒鐘」和「字幕出現秒數」兩個欄位（見下兩圖），若使用者要填上「負數」，會遇到數值歸零的問題。

<img width="1416" alt="截圖 2024-09-27 晚上11 02 17" src="https://github.com/user-attachments/assets/b350b196-3529-4bbf-86ed-fbe831702ba9">

<img width="1498" alt="截圖 2024-09-27 晚上11 01 35" src="https://github.com/user-attachments/assets/531ae83b-0782-4292-a436-f2cfa8a4ce48">


### Reference
[Asana Card](https://app.asana.com/0/1205812314629278/1208300630178299/f)