### PR TITLE
fix(public-cms): remove dangling files when validation errors occur

### DIFF
--- a/packages/public-cms/lists/audio.ts
+++ b/packages/public-cms/lists/audio.ts
@@ -10,11 +10,11 @@ import {
 import {
   createdByFilter,
   createdByHooks,
-  createStorageHooks,
+  createFileFieldHooks,
 } from './utils/access-control-list'
 
 const limit = 5
-const storageHooks = createStorageHooks('Audio', limit)
+const fileFieldHooks = createFileFieldHooks(limit, config.files.storagePath)
 
 const listConfigurations = list({
   graphql: {
@@ -28,6 +28,13 @@ const listConfigurations = list({
     file: file({
       label: '檔案',
       storage: 'files',
+      hooks: {
+        validateInput: async (args) => {
+          if (typeof fileFieldHooks.validateInput === 'function') {
+            return await fileFieldHooks.validateInput(args)
+          }
+        },
+      },
     }),
     url: virtual({
       label: '音檔網址',
@@ -103,11 +110,6 @@ const listConfigurations = list({
         return createdByHooks.resolveInput(args)
       }
       return args.resolvedData
-    },
-    validateInput: async (args) => {
-      if (typeof storageHooks.validateInput === 'function') {
-        await storageHooks?.validateInput(args)
-      }
     },
   },
 })

--- a/packages/public-cms/lists/photo.ts
+++ b/packages/public-cms/lists/photo.ts
@@ -10,10 +10,10 @@ import {
 import {
   createdByFilter,
   createdByHooks,
-  createStorageHooks,
+  createImageFieldHooks,
 } from './utils/access-control-list'
 const limit = 5
-const storageHooks = createStorageHooks('Photo', limit)
+const imageFieldHooks = createImageFieldHooks(limit, config.images.storagePath)
 
 const listConfigurations = list({
   fields: {
@@ -23,6 +23,13 @@ const listConfigurations = list({
     }),
     imageFile: image({
       storage: 'images',
+      hooks: {
+        validateInput: async (args) => {
+          if (typeof imageFieldHooks.validateInput === 'function') {
+            return await imageFieldHooks.validateInput(args)
+          }
+        },
+      },
     }),
     url: virtual({
       label: '照片網址',
@@ -97,11 +104,6 @@ const listConfigurations = list({
         return createdByHooks.resolveInput(args)
       }
       return args.resolvedData
-    },
-    validateInput: async (args) => {
-      if (typeof storageHooks.validateInput === 'function') {
-        await storageHooks?.validateInput(args)
-      }
     },
   },
 })

--- a/packages/public-cms/lists/video.ts
+++ b/packages/public-cms/lists/video.ts
@@ -10,11 +10,11 @@ import {
 import {
   createdByFilter,
   createdByHooks,
-  createStorageHooks,
+  createFileFieldHooks,
 } from './utils/access-control-list'
 
 const limit = 5
-const storageHooks = createStorageHooks('Video', limit)
+const fileFieldHooks = createFileFieldHooks(limit, config.files.storagePath)
 
 const listConfigurations = list({
   fields: {
@@ -25,6 +25,13 @@ const listConfigurations = list({
     file: file({
       label: '檔案',
       storage: 'files',
+      hooks: {
+        validateInput: async (args) => {
+          if (typeof fileFieldHooks.validateInput === 'function') {
+            return await fileFieldHooks.validateInput(args)
+          }
+        },
+      },
     }),
     url: virtual({
       label: '影片網址',
@@ -98,11 +105,6 @@ const listConfigurations = list({
         return createdByHooks.resolveInput(args)
       }
       return args.resolvedData
-    },
-    validateInput: async (args) => {
-      if (typeof storageHooks.validateInput === 'function') {
-        await storageHooks?.validateInput(args)
-      }
     },
   },
 })


### PR DESCRIPTION
## Bug 描述
使用者試圖上傳第六個檔案時，系統在 `validateInput` hook 階段，會去計算使用者已經上傳的檔案，如果超過五個，hook 會停止後續動作，不將檔案寫入資料庫裡。
但因為 keystone 的 `image` 和 `file` field 並不會因為 hook error，而將已經上傳至伺服器的檔案刪除，導致會出現資料庫沒有資料，但 storage 卻有檔案的異常情況。

## 解法
目前的解法是當 `validateInput` 發生錯誤時，手動將已經上傳的檔案刪除。

## Reference
Asana Card: https://app.asana.com/0/1205812314629278/1208640015413499/f