### PR TITLE
fix(public-cms): can not delete file due to absolute path of `storagePath`

### DIFF
--- a/packages/public-cms/lists/utils/access-control-list.ts
+++ b/packages/public-cms/lists/utils/access-control-list.ts
@@ -120,6 +120,12 @@ export const createdByHooks: ListHooks<BaseListTypeInfo> = {
   },
 }
 
+const getAbsoluteFilePath = (storagePath: string) => {
+  const workingDir = process.cwd()
+  const relativePath = path.relative(workingDir, storagePath)
+  return path.resolve(workingDir, relativePath)
+}
+
 export const createFileFieldHooks = (
   limit: number,
   storagePath: string
@@ -158,7 +164,7 @@ export const createFileFieldHooks = (
           // `file` field won't delete the uploaded file.
           // Hence, we need to delete the file manually here.
           const filename = resolvedData?.[fieldKey]?.filename
-          const filepath = path.join(process.cwd(), storagePath, filename)
+          const filepath = path.join(getAbsoluteFilePath(storagePath), filename)
           try {
             console.log(
               JSON.stringify({
@@ -232,8 +238,7 @@ export const createImageFieldHooks = (
           const id = resolvedData?.[fieldKey]?.id
           const extension = resolvedData?.[fieldKey]?.extension
           const filepath = path.join(
-            process.cwd(),
-            storagePath,
+            getAbsoluteFilePath(storagePath),
             `${id}.${extension}`
           )
           try {


### PR DESCRIPTION
## Bug 描述
因為 Cloud Run 上面提供的 `storagePath` 是絕對路徑，所以 `fileFieldHooks.validateInput` 會產生錯誤的檔案路徑，導致無法正確刪除多餘的檔案。

## 解決辦法
使用 `path.relative` 去計算 working directory 和 `storagePath` 之間的相對路徑，再透過該相對路徑產生正確的絕對路徑。