### PR TITLE
feat(tsc): build esmodule and commonjs codes  

### DIFF
--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -32,7 +32,7 @@
     "@story-telling-reporter/react-scrollable-image": "0.2.0",
     "@story-telling-reporter/react-scrollable-video": "3.0.0",
     "@story-telling-reporter/react-subtitled-audio": "1.1.1",
-    "@story-telling-reporter/react-three-story-controls": "2.0.0",
+    "@story-telling-reporter/react-three-story-controls": "2.2.0",
     "lodash": "^4.17.21",
     "serialize-javascript": "^6.0.0"
   },

--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-embed-code-generator",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/embed-code-generator/src/build-code/scrollable-three-model.js
+++ b/packages/embed-code-generator/src/build-code/scrollable-three-model.js
@@ -10,7 +10,7 @@ Promise.all([
      * Directly import file to avoid bundling redundant files.
      */
     /* webpackChunkName: "react-three-story-controls" */
-    '@story-telling-reporter/react-three-story-controls/lib/react-components/scrollable-three-model'
+    '@story-telling-reporter/react-three-story-controls/lib/esm/react-components/scrollable-three-model.js'
   ),
   import('./constants'),
   import('regenerator-runtime/runtime'),

--- a/packages/three-story-controls/Makefile
+++ b/packages/three-story-controls/Makefile
@@ -10,12 +10,12 @@ dev:
 
 build-commonjs: 
 	@echo "$(P) use babel to transpile typescript into commonjs"
-	mkdir -p lib
-	NODE_ENV=production yarn babel src --out-dir lib --extensions '.ts,.tsx,.js,.jsx' --copy-files --root-mode upward
+	mkdir -p lib/cjs
+	NODE_ENV=production yarn babel src --out-dir lib/cjs --extensions '.ts,.tsx,.js,.jsx' --copy-files --root-mode upward
 
 build-esmodule:
 	@echo "$(P) use rollup to transpile typescript into esmodule"
-	mkdir -p lib
+	mkdir -p lib/esm
 	yarn rollup -c rollup.config.mjs
 
 build: clean build-commonjs build-esmodule

--- a/packages/three-story-controls/Makefile
+++ b/packages/three-story-controls/Makefile
@@ -8,15 +8,20 @@ dev:
 	@echo "$(P) Start webpack dev server"
 	NODE_ENV=development yarn webpack serve -c dev/webpack.config.mjs
 
-build-lib:
-	@echo "$(P) Transpile source codes to commonjs and esmodule"
+build-commonjs: 
+	@echo "$(P) use babel to transpile typescript into commonjs"
+	mkdir -p lib
+	NODE_ENV=production yarn babel src --out-dir lib --extensions '.ts,.tsx,.js,.jsx' --copy-files --root-mode upward
+
+build-esmodule:
+	@echo "$(P) use rollup to transpile typescript into esmodule"
 	mkdir -p lib
 	yarn rollup -c rollup.config.mjs
 
-build: clean build-lib
+build: clean build-commonjs build-esmodule
 
 clean:
 	@echo "$(P) Clean lib/"
 	rm -rf lib/
 
-.PHONY: build clean dev build-lib
+.PHONY: build clean dev build-commonjs build-esmodule

--- a/packages/three-story-controls/Makefile
+++ b/packages/three-story-controls/Makefile
@@ -9,9 +9,9 @@ dev:
 	NODE_ENV=development yarn webpack serve -c dev/webpack.config.mjs
 
 build-lib:
-	@echo "$(P) Transpile source codes to commonjs syntax"
+	@echo "$(P) Transpile source codes to commonjs and esmodule"
 	mkdir -p lib
-	NODE_ENV=production yarn babel src --out-dir lib --extensions '.ts,.tsx,.js,.jsx' --copy-files --root-mode upward
+	yarn rollup -c rollup.config.mjs
 
 build: clean build-lib
 

--- a/packages/three-story-controls/package.json
+++ b/packages/three-story-controls/package.json
@@ -2,8 +2,8 @@
   "name": "@story-telling-reporter/react-three-story-controls",
   "version": "2.1.1",
   "description": "",
-  "main": "lib/index.js",
-  "module": "lib/index.esm.js",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
   "types": "types/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/three-story-controls/package.json
+++ b/packages/three-story-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-three-story-controls",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/three-story-controls/package.json
+++ b/packages/three-story-controls/package.json
@@ -2,7 +2,7 @@
   "name": "@story-telling-reporter/react-three-story-controls",
   "version": "2.1.0",
   "description": "",
-  "main": "lib/index.cjs.js",
+  "main": "lib/index.js",
   "module": "lib/index.esm.js",
   "types": "types/index.d.ts",
   "scripts": {

--- a/packages/three-story-controls/package.json
+++ b/packages/three-story-controls/package.json
@@ -2,14 +2,14 @@
   "name": "@story-telling-reporter/react-three-story-controls",
   "version": "2.0.0",
   "description": "",
-  "main": "lib/index.js",
+  "main": "lib/index.cjs.js",
+  "module": "lib/index.esm.js",
   "types": "types/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "make dev",
-    "build": "make build",
     "clean": "make clean",
-    "build-lib": "make build-lib"
+    "build": "make build"
   },
   "repository": {
     "type": "git",
@@ -36,10 +36,14 @@
   "devDependencies": {
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
+    "@rollup/plugin-commonjs": "^28.0.2",
+    "@rollup/plugin-node-resolve": "^16.0.0",
+    "@rollup/plugin-typescript": "^12.1.2",
     "@story-telling-reporter/draft-editor": "^2.1.0",
     "@types/three": "^0.165.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "rollup": "^4.31.0",
     "styled-components": "5.3.5"
   },
   "peerDependencies": {

--- a/packages/three-story-controls/package.json
+++ b/packages/three-story-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-three-story-controls",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/packages/three-story-controls/package.json
+++ b/packages/three-story-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-three-story-controls",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",

--- a/packages/three-story-controls/rollup.config.mjs
+++ b/packages/three-story-controls/rollup.config.mjs
@@ -9,10 +9,6 @@ export default {
       file: 'lib/index.esm.js', // output esmodule
       format: 'es',
     },
-    {
-      file: 'lib/index.cjs.js', // output commonjs
-      format: 'cjs',
-    },
   ],
   plugins: [
     resolve(),

--- a/packages/three-story-controls/rollup.config.mjs
+++ b/packages/three-story-controls/rollup.config.mjs
@@ -1,0 +1,25 @@
+import resolve from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: [
+    {
+      file: 'lib/index.esm.js', // output esmodule
+      format: 'es',
+    },
+    {
+      file: 'lib/index.cjs.js', // output commonjs
+      format: 'cjs',
+    },
+  ],
+  plugins: [
+    resolve(),
+    commonjs(),
+    typescript({
+      tsconfig: './tsconfig.json',
+    }),
+  ],
+  external: ['react', 'three-story-controls', 'three', 'lodash', 'gsap', 'draft-js', 'axios', '@gsap/react', 'nanoid'] // 將不需要打包的依賴列在這裡，例如 ['react', 'lodash']
+}

--- a/packages/three-story-controls/rollup.config.mjs
+++ b/packages/three-story-controls/rollup.config.mjs
@@ -1,15 +1,28 @@
-import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
+import glob from 'glob'
+import path from 'node:path'
+import resolve from '@rollup/plugin-node-resolve'
 import typescript from '@rollup/plugin-typescript'
+import { fileURLToPath } from 'node:url'
 
 export default {
-  input: 'src/index.ts',
-  output: [
-    {
-      file: 'lib/index.esm.js', // output esmodule
-      format: 'es',
-    },
-  ],
+  input: Object.fromEntries(
+    glob.sync('src/**/*.{ts,tsx}').map(file => [
+      // This removes `src/` as well as the file extension from each
+      // file, so e.g. src/nested/foo.js becomes nested/foo
+      path.relative(
+        'src',
+        file.slice(0, file.length - path.extname(file).length)
+      ),
+      // This expands the relative paths to absolute paths, so e.g.
+      // src/nested/foo becomes /project/src/nested/foo.js
+      fileURLToPath(new URL(file, import.meta.url))
+    ])
+  ),
+  output: {
+    format: 'es',
+    dir: 'lib/esm'
+  },
   plugins: [
     resolve(),
     commonjs(),
@@ -17,5 +30,5 @@ export default {
       tsconfig: './tsconfig.json',
     }),
   ],
-  external: ['react', 'three-story-controls', 'three', 'lodash', 'gsap', 'draft-js', 'axios', '@gsap/react', 'nanoid'] // 將不需要打包的依賴列在這裡，例如 ['react', 'lodash']
+  external: ['react', 'three-story-controls', 'three', /^three\//, 'lodash', /^lodash\//, 'gsap', /^gsap\//, 'draft-js', 'axios', '@gsap/react', 'nanoid', 'styled-components', '@story-telling-reporter/draft-editor', '@keystone-ui/fields', '@keystone-ui/modals', 'immutable']
 }

--- a/packages/three-story-controls/types/index.d.ts
+++ b/packages/three-story-controls/types/index.d.ts
@@ -17,7 +17,7 @@ export {
   ThreePOI,
   GTLFModelObject,
   GLTF,
-} from '../src/type'
+} from '../src/types'
 
 export {
   CameraHelper,


### PR DESCRIPTION
### 任務說明
因為之前 build 出來的 esmodule 程式碼存在 bug，所以停止 pkg `@story-telling-reporter/react-three-story-controls` 輸出 esmodule 的程式碼（見 https://github.com/nickhsine/story-telling-monorepo/pull/34  ），僅輸出 commonjs 的版本。

但因為 `@story-telling-reporter/react-three-story-controls` 的 commonjs 程式碼裡，有 require `three/examples/jsm/loaders/GLTFLoader.js` 和 `three/examples/jsm/loaders/DRACOLoader.js`；然而，`GLTFLoader.js` 和 `DRACOLoader.js` 並沒有提供 commonjs 的版本，僅提供 esmodule 的版本，所以會出現 commonjs 程式碼無法 require esmodule 程式碼的問題。

此問題會導致 cms 起 server 時，無法正確 import  `@story-telling-reporter/react-three-story-controls` ，出現以下錯誤：
```
error - ../../../three-story-controls/lib/loader.js:8:18
Module not found: ESM packages (three/examples/jsm/loaders/GLTFLoader.js) need to be imported. Use 'import' to reference the package instead. https://nextjs.org/docs/messages/import-esm-externals
   6 | exports.loadGltfModel = exports.getModelFileSize = void 0;
   7 | var _axios = _interopRequireDefault(require("axios"));
>  8 | var _GLTFLoader = require("three/examples/jsm/loaders/GLTFLoader.js");
     |                  ^
   9 | var _DRACOLoader = require("three/examples/jsm/loaders/DRACOLoader.js");
  10 | function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
  11 | /**

https://nextjs.org/docs/messages/module-not-found

Import trace for requested module:
../../../three-story-controls/lib/react-components/loading-progress.js
../../../three-story-controls/lib/react-components/scrollable-three-model.js
../../../three-story-controls/lib/index.js
../../lists/views/scrollable-three-model/index.tsx
./pages/_app.js
```

### 解決辦法
輸出 `@story-telling-reporter/react-three-story-controls` esmodule 版本。
使用 `rollup`  將程式碼從 typescript 轉譯成 esmodule 版本，並且存放於 `lib/esm/` 資料夾底下。

cms 在 import `@story-telling-reporter/react-three-story-controls` 時，會選擇 `lib/esm/` 底下的 esmodule 程式碼，而不會採用 commonjs 的版本。如此一來，就不會出現 commonjs require esmodule 的問題。
