### PR TITLE
fix,refactor(scrollable-image): not work in kids article page and custom css indication for kids

### DIFF
--- a/packages/scrollable-image/package.json
+++ b/packages/scrollable-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-scrollable-image",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "",
   "main": "lib/index.js",
   "module": "lib/esm/index.js",

--- a/packages/scrollable-image/src/cms-editor/index.tsx
+++ b/packages/scrollable-image/src/cms-editor/index.tsx
@@ -191,8 +191,8 @@ export function ScrollableImageEditor({
   const customCss =
     siProps.customCss ||
     `
-  /* 將捲動式影片往上移動，使其與上一個區塊連接在一起。*/
-  /* 使用情境範例：想要兩個捲動式影片連在一起，讓第二個捲動式影片與第一個影片沒有間隔。 */
+  /* 給報導者文章頁使用 */
+  /* 將元件往上移動，使其與上一個區塊連接在一起。*/
   /* 刪除下方註解即可使用。 */
   /*
   .${className} {
@@ -200,7 +200,8 @@ export function ScrollableImageEditor({
   }
   */
 
-  /* 將捲動式影片向左移動，撐滿文章頁 */
+  /* 給報導者文章頁使用 */
+  /* 將元件向左移動，撐滿文章頁 */
   /* 刪除下方註解即可使用。 */
   /*
   @media (max-width: 767px) {
@@ -224,6 +225,23 @@ export function ScrollableImageEditor({
   @media (min-width: 1440px) {
     .${className} {
       margin-left: calc((100vw - 730px)/2 * -1);
+    }
+  }
+  */
+
+  /* 給少年報導者文章頁使用 */
+  /* 將元件向左移動，撐滿文章頁 */
+  /* 刪除下方註解即可使用。 */
+  /*
+  @media (max-width: 767px) {
+    .${className} {
+      margin-left: -5vw;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .${className} {
+      margin-left: calc((100vw - 700px)/2 * -1);
     }
   }
   */

--- a/packages/scrollable-image/src/scrollable-image.tsx
+++ b/packages/scrollable-image/src/scrollable-image.tsx
@@ -45,6 +45,7 @@ const Img = styled.img`
   height: 100%;
   border: none;
   user-select: none;
+  max-width: none;
 `
 
 const CaptionBlock = styled.div`


### PR DESCRIPTION
### Bug 修復
scrollable-image embed code 在少年報導者文章頁會壞掉，原因是文章頁 css `img { max-width: 100%; }` 的影響，導致 scrollable-image 的 img 被壓縮，無法呈現橫著滾的效果。
commit [502841e](https://github.com/lab-reporter/storytelling-monorepo/pull/44/commits/502841e7da9935c05ddadc879ee184a4cf69a583) 加上 `max-width: none;` 去 overwrite 文章頁的 css。

### 調整 custom CSS 的預設值
原本的 custom CSS 預設值僅提供報導者文章頁使用，新增少年報導者文章頁的版本。