### PR TITLE
fix(ui-toolkit,scroll-to-audio): fix(ui-toolkit,scroll-to-audio): solve audio, video autoplay problems on Safari

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -19,7 +19,7 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",
     "@story-telling-reporter/draft-editor": "^2.1.0",
-    "@story-telling-reporter/react-embed-code-generator": "2.2.7",
+    "@story-telling-reporter/react-embed-code-generator": "2.2.8",
     "@story-telling-reporter/react-scrollable-image": "0.3.3",
     "@story-telling-reporter/react-scrollable-video": "3.0.0",
     "@story-telling-reporter/react-three-story-controls": "2.2.0",

--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-embed-code-generator",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@story-telling-reporter/react-karaoke": "1.0.0",
-    "@story-telling-reporter/react-scroll-to-audio": "3.0.0",
+    "@story-telling-reporter/react-scroll-to-audio": "3.0.1",
     "@story-telling-reporter/react-scrollable-image": "0.3.3",
     "@story-telling-reporter/react-scrollable-video": "3.0.0",
     "@story-telling-reporter/react-subtitled-audio": "1.1.1",

--- a/packages/scroll-to-audio/package.json
+++ b/packages/scroll-to-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-scroll-to-audio",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@story-telling-reporter/react-ui-toolkit": "1.0.0",
+    "@story-telling-reporter/react-ui-toolkit": "1.1.0",
     "lodash": "^4.17.21",
     "react-intersection-observer": "^9.3.5"
   },

--- a/packages/scroll-to-audio/src/index.tsx
+++ b/packages/scroll-to-audio/src/index.tsx
@@ -41,6 +41,10 @@ function ScrollToAudio({
   }, [])
 
   useEffect(() => {
+    if (hintOnly) {
+      return
+    }
+
     const handleScroll = _.debounce(() => {
       const topEntryElement = topEntryPointRef.current
       const bottomEntryElement = bottomEntryPointRef.current
@@ -51,7 +55,7 @@ function ScrollToAudio({
         topEntryElement.getBoundingClientRect().height == 0
       ) {
         console.log(
-          '[react-scroll-to-audio] `topEntryElement` is not available. Remove scroll event listener.'
+          `[react-scroll-to-audio][${id}] \`topEntryElement\` is not available. Remove scroll event listener.`
         )
         window.removeEventListener('scroll', handleScroll)
         return
@@ -102,17 +106,17 @@ function ScrollToAudio({
     }, 50)
 
     console.log(
-      `[react-scroll-to-audio] add scroll event listener. \`muted\` state is ${muted}`
+      `[react-scroll-to-audio][${id}] add scroll event listener. \`muted\` state is ${muted}`
     )
     window.addEventListener('scroll', handleScroll)
 
     return () => {
       console.log(
-        '[react-scroll-to-audio] useEffect cleanup function. Remove scroll event listener.'
+        `[react-scroll-to-audio][${id}] useEffect cleanup function. Remove scroll event listener.`
       )
       window.removeEventListener('scroll', handleScroll)
     }
-  }, [muted])
+  }, [muted, hintOnly])
 
   // set audio muted attribute according to browser muted state
   useEffect(() => {
@@ -131,21 +135,23 @@ function ScrollToAudio({
 
     if (paused) {
       audioElement.pause()
-      console.log('[react-scroll-to-audio] audio paused.')
+      console.log(`[react-scroll-to-audio][${id}] audio paused.`)
     } else {
       const startPlayPromise = audioElement.play()
       if (startPlayPromise !== undefined) {
         startPlayPromise
           // play successfully
           .then(() => {
-            console.log('[react-scroll-to-audio] audio plays successfully.')
+            console.log(
+              `[react-scroll-to-audio][${id}] audio plays successfully.`
+            )
             audioElement.setAttribute('data-played', 'true')
           })
           // fail to play
           .catch((error) => {
             // browser prevent from playing audio before user interactions
-            console.log('[react-scroll-to-audio] unable to play audio')
-            console.log('[react-scroll-to-audio] error: ', error)
+            console.log(`[react-scroll-to-audio][${id}] unable to play audio`)
+            console.log(`[react-scroll-to-audio][${id}] error: `, error)
 
             // pause audio since browser does not allow to play it
             setPaused(true)

--- a/packages/scroll-to-audio/src/index.tsx
+++ b/packages/scroll-to-audio/src/index.tsx
@@ -160,6 +160,13 @@ function ScrollToAudio({
 
     // pause audio if muted, otherwise play the audio
     setPaused(nextMuted)
+
+    // Through this user interaction,
+    // trigger other scroll-to-audio elements to play sound as well,
+    // to prevent the browser from blocking playback later.
+    hooks.testPlayOtherMediaElements({
+      excludeElement: audioRef.current,
+    })
   }
 
   const bottomEntryId = id + '-bottom-entry-point'

--- a/packages/ui-toolkit/index.d.ts
+++ b/packages/ui-toolkit/index.d.ts
@@ -1,10 +1,15 @@
-import { useMuted, useIOSCornerCaseFix } from './src/hooks'
+import {
+  useMuted,
+  useIOSCornerCaseFix,
+  testPlayOtherMediaElements,
+} from './src/hooks'
 import { Hint } from './src/twreporter/index'
 import { Hint as KidsHint } from './src/kids/index'
 
 export type Hooks = {
   useMuted: useMuted
   useIOSCornerCaseFix: useIOSCornerCaseFix
+  testPlayOtherMediaElements: testPlayOtherMediaElements
 }
 
 export type Twreporter = {

--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-ui-toolkit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/ui-toolkit/src/hooks.tsx
+++ b/packages/ui-toolkit/src/hooks.tsx
@@ -101,7 +101,8 @@ export function useMuted(
     )
     otherMediaElements.forEach((ele) => {
       console.log(
-        `[react-ui-toolkit] set story telling element attribute 'data-muted=${muted.toString()}'`
+        `[react-ui-toolkit] set attribute 'data-muted=${muted.toString()}' on media element:`,
+        ele
       )
       ele.setAttribute('data-muted', muted.toString())
     })
@@ -139,13 +140,61 @@ export function useMuted(
     window['__twreporter_story_telling_ui_toolkit'] = {
       muted: _muted,
     }
+
     _setMuted(_muted)
   }
 
   return [muted, setMuted]
 }
 
+export const testPlayOtherMediaElements = ({
+  excludeElement,
+}: { excludeElement?: HTMLMediaElement } = {}) => {
+  const otherMediaElements: NodeListOf<HTMLMediaElement> =
+    document.querySelectorAll(
+      `[data-twreporter-story-telling][data-played="false"]`
+    )
+
+  if (otherMediaElements.length > 0) {
+    console.log('[react-ui-toolkit] plays other media elements.')
+  }
+
+  otherMediaElements.forEach((ele) => {
+    if (ele === excludeElement) {
+      return
+    }
+
+    console.log(`[react-ui-toolkit] plays media element:`, ele)
+    const startPlayPromise = ele.play()
+    if (startPlayPromise !== undefined) {
+      startPlayPromise
+        // play successfully
+        .then(() => {
+          console.log(
+            `[react-ui-toolkit] media element: `,
+            ele,
+            'plays successfully.'
+          )
+          ele.setAttribute('data-played', 'true')
+          // `pause()` video after `play()` successfully
+          ele.pause()
+        })
+        // fail to play
+        .catch((error) => {
+          // browser prevent from playing audio before user interactions
+          console.log(
+            `[react-ui-toolkit] unable to play media element:`,
+            ele,
+            'Error:',
+            error
+          )
+        })
+    }
+  })
+}
+
 export default {
   useIOSCornerCaseFix,
   useMuted,
+  testPlayOtherMediaElements,
 }

--- a/packages/ui-toolkit/src/kids/hint.tsx
+++ b/packages/ui-toolkit/src/kids/hint.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 import styled from '../styled-components'
 import { MuteIcon, SoundIcon } from './icons'
 import { mediaQuery } from './utils/media-query'
-import { useMuted } from '../hooks'
+import { useMuted, testPlayOtherMediaElements } from '../hooks'
 
 export function Hint({
   className,
@@ -30,6 +30,11 @@ export function Hint({
       <Button
         onClick={() => {
           setMuted(!muted)
+
+          // Through this user interaction,
+          // trigger other scroll-to-audio elements to play sound as well,
+          // to prevent the browser from blocking playback later.
+          testPlayOtherMediaElements()
         }}
       >
         <Icon>{muted ? <MuteIcon /> : <SoundIcon />}</Icon>

--- a/packages/ui-toolkit/src/twreporter/hint.tsx
+++ b/packages/ui-toolkit/src/twreporter/hint.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 import styled from '../styled-components'
 import { MuteIcon, SoundIcon, SeparationLine } from './icons'
 import { mediaQuery } from './utils/media-query'
-import { useMuted } from '../hooks'
+import { useMuted, testPlayOtherMediaElements } from '../hooks'
 
 export function Hint({ className, id }: { className?: string; id: string }) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -27,6 +27,11 @@ export function Hint({ className, id }: { className?: string; id: string }) {
         className={muted ? 'dark' : 'light'}
         onClick={() => {
           setMuted(!muted)
+
+          // Through this user interaction,
+          // trigger other scroll-to-audio elements to play sound as well,
+          // to prevent the browser from blocking playback later.
+          testPlayOtherMediaElements()
         }}
       >
         {muted ? <span>開啟聲音</span> : <span>關閉聲音</span>}


### PR DESCRIPTION
### Bug 描述
在 iOS Safari 上，舉此篇[文章](https://www.twreporter.org/a/new-close-relationships-loneliness-economy-comic)為例，當多個 scroll-to-audio 元件同時使用時，會遇到部分的元件可以成功自動播放，部分的元件不可。

Safari 的 error 訊息：
`NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.`

### 解決辦法
目前的程式碼，在當使用者點擊聲音按鈕時，所有的 scroll-to-audio 元件都會被 event 觸發，照理來說，應該符合瀏覽器 autoplay 的政策，所以還不確定 root cause 為何。
由於不確定 root cause 為何，所以在這個 PR 裡，加強 event 觸發後的行為：短暫地播放 audio。

此 PR 需要上到 production 測試才能知道 workaround 是否可行。
