### PR TITLE
fix(ecg): initial installation fails due to postinstall script

### DIFF
--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -10,7 +10,7 @@
     "clean": "make clean",
     "build-dist": "make build-dist",
     "build-lib": "make build-lib",
-    "postinstall": "make build-lib"
+    "postinstall": "make build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Bug 說明
在初始安裝時，`packages/cms` 和 `packages/public-cms` 都會需要使用 build 好的 `packages/embed-code-generator`。
然而目前的 `make build-lib` 是不夠的，會少 build 出 webpack bundles 和 `manifest.json`，導致程式碼無法正常運行。

### 解決辦法
更改 `postinstall` script，不僅 build source code (`make build-lib`)，也同時 build webpack bundles 和 `manifest.json` (`make build`)。