### PR TITLE
feat(public-cms): add ScrollableImage list

### DIFF
--- a/packages/cms/admin/components/custom-navigation.tsx
+++ b/packages/cms/admin/components/custom-navigation.tsx
@@ -16,7 +16,6 @@ export function CustomNavigation({
       <ListNavItems lists={lists.slice(0, lists.length - 1)} />
       <NavItem href="/iframe/timeline">大事記</NavItem>
       <NavItem href="/iframe/dual-channel">左右互搏</NavItem>
-      <NavItem href="/iframe/scrollable-image">橫著滾吧</NavItem>
       <NavItem href="/iframe/zoom-in">大圖點我</NavItem>
     </NavigationContainer>
   )

--- a/packages/cms/lists/index.ts
+++ b/packages/cms/lists/index.ts
@@ -20,8 +20,8 @@ export const listDefinition = {
   Karaoke,
   SubtitledAudio,
   ScrollToAudio,
-  ScrollableThreeModel,
   ScrollableVideo,
   ScrollableImage,
+  ScrollableThreeModel,
   ThreeModel,
 }

--- a/packages/cms/lists/scrollable-image.ts
+++ b/packages/cms/lists/scrollable-image.ts
@@ -99,7 +99,7 @@ const listConfigurations = list({
           })
           const css = (editorState.customCss as string) ?? ''
 
-          return `<!-- 捲動式影片：${item.name} --><style>${css}</style>${code}`
+          return `<!-- 橫著滾吧！：${item.name} --><style>${css}</style>${code}`
         },
       }),
       ui: {

--- a/packages/public-cms/admin/components/custom-navigation.tsx
+++ b/packages/public-cms/admin/components/custom-navigation.tsx
@@ -19,7 +19,6 @@ export function CustomNavigation({
       <ListNavItems lists={lists.slice(0, lists.length - 1)} />
       <NavItem href="/iframe/timeline">大事記</NavItem>
       <NavItem href="/iframe/dual-channel">左右互搏</NavItem>
-      <NavItem href="/iframe/scrollable-image">橫著滾吧</NavItem>
       <NavItem href="/iframe/zoom-in">大圖點我</NavItem>
       <ListNavItems lists={[ScrollableThreeModel]} />
     </NavigationContainer>

--- a/packages/public-cms/lists/index.ts
+++ b/packages/public-cms/lists/index.ts
@@ -3,6 +3,7 @@ import Photo from './photo'
 import ScrollToAudio from './scroll-to-audio'
 import ScrollableThreeModel from './scrollable-three-model'
 import ScrollableVideo from './scrollable-video'
+import ScrollableImage from './scrollable-image'
 import User from './user'
 import Video from './video'
 
@@ -13,5 +14,6 @@ export const listDefinition = {
   Photo,
   ScrollToAudio,
   ScrollableVideo,
+  ScrollableImage,
   ScrollableThreeModel,
 }

--- a/packages/public-cms/lists/scrollable-image.ts
+++ b/packages/public-cms/lists/scrollable-image.ts
@@ -1,0 +1,131 @@
+import { ScrollableImageEditorProps } from '@story-telling-reporter/react-scrollable-image'
+import { buildScrollableImageEmbedCode } from '@story-telling-reporter/react-embed-code-generator'
+import { graphql, list } from '@keystone-6/core'
+import { text, json, virtual } from '@keystone-6/core/fields'
+
+const className = 'storytelling-react-scrollable-image-container'
+const customCss = `
+  /* 給報導者文章頁使用 */
+  /* 將元件往上移動，使其與上一個區塊連接在一起。*/
+  /* 刪除下方註解即可使用。 */
+  /*
+  .${className} {
+    margin-top: -40px;
+  }
+  */
+
+  /* 給報導者文章頁使用 */
+  /* 將元件向左移動，撐滿文章頁 */
+  /* 刪除下方註解即可使用。 */
+  /*
+  @media (max-width: 767px) {
+    .${className} {
+      margin-left: -3.4vw;
+    }
+  }
+
+  @media (min-width: 768px) and (max-width: 1023px) {
+    .${className} {
+      margin-left: calc((100vw - 512px)/2 * -1);
+    }
+  }
+
+  @media (min-width: 1024px) and (max-width: 1439px) {
+    .${className} {
+      margin-left: calc((100vw - 550px)/2 * -1);
+    }
+  }
+
+  @media (min-width: 1440px) {
+    .${className} {
+      margin-left: calc((100vw - 730px)/2 * -1);
+    }
+  }
+  */
+
+  /* 給少年報導者文章頁使用 */
+  /* 將元件向左移動，撐滿文章頁 */
+  /* 刪除下方註解即可使用。 */
+  /*
+  @media (max-width: 767px) {
+    .${className} {
+      margin-left: -5vw;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .${className} {
+      margin-left: calc((100vw - 700px)/2 * -1);
+    }
+  }
+  */
+`
+
+const listConfigurations = list({
+  fields: {
+    name: text({
+      label: 'Scorllable Image 名稱',
+      validation: { isRequired: true },
+    }),
+    editorState: json({
+      label: '編輯圖片和字幕',
+      defaultValue: {
+        captions: [],
+        imgObjs: [],
+        customCss,
+        className,
+      },
+      ui: {
+        // A module path that is resolved from where `keystone start` is run
+        views: './lists/views/scrollable-image-editor/index',
+        createView: {
+          fieldMode: 'hidden',
+        },
+      },
+    }),
+    embedCode: virtual({
+      label: 'embed code',
+      field: graphql.field({
+        type: graphql.String,
+        resolve: async (item: Record<string, unknown>): Promise<string> => {
+          const editorState = item?.editorState as ScrollableImageEditorProps
+          const code = buildScrollableImageEmbedCode({
+            className,
+            imgObjs: editorState.imgObjs,
+            captions: editorState.captions,
+            darkMode: editorState.theme === 'dark_mode',
+            minHeight: editorState.minHeight,
+            maxHeight: editorState.maxHeight,
+          })
+          const css = (editorState.customCss as string) ?? ''
+
+          return `<!-- 橫著滾吧！：${item.name} --><style>${css}</style>${code}`
+        },
+      }),
+      ui: {
+        // A module path that is resolved from where `keystone start` is run
+        views: './lists/views/embed-code',
+        createView: {
+          fieldMode: 'hidden',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
+      },
+    }),
+  },
+  ui: {
+    label: '橫著滾吧！',
+    listView: {
+      initialSort: { field: 'id', direction: 'DESC' },
+      initialColumns: ['name'],
+      pageSize: 50,
+    },
+    labelField: 'name',
+  },
+
+  access: () => true,
+  hooks: {},
+})
+
+export default listConfigurations

--- a/packages/public-cms/lists/views/scrollable-image-editor/index.tsx
+++ b/packages/public-cms/lists/views/scrollable-image-editor/index.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useCallback } from 'react'
+import { FieldProps } from '@keystone-6/core/types'
+import { FieldContainer, FieldLabel } from '@keystone-ui/fields'
+import { controller } from '@keystone-6/core/fields/types/json/views'
+import {
+  ScrollableImageEditor,
+  ScrollableImageEditorProps,
+} from '@story-telling-reporter/react-scrollable-image'
+
+export const Field = ({
+  field,
+  value,
+  onChange: onFieldChange,
+}: FieldProps<typeof controller>) => {
+  const [siProps, setSiProps] = useState<ScrollableImageEditorProps>(
+    value ? JSON.parse(value) : {}
+  )
+  const [prevValue, setPrevValue] = useState(value)
+
+  if (value !== prevValue) {
+    setPrevValue(value)
+    setSiProps(value ? JSON.parse(value) : {})
+  }
+
+  const onChange = useCallback(
+    (newValue: ScrollableImageEditorProps) => {
+      onFieldChange?.(JSON.stringify(newValue))
+    },
+    [onFieldChange]
+  )
+
+  return (
+    <FieldContainer style={{ maxWidth: '700px' }}>
+      <FieldLabel>{field.label}</FieldLabel>
+      <div
+        style={{ position: 'relative', zIndex: 30, backgroundColor: '#fff' }}
+      >
+        {' '}
+        {/* add zIndex to be in front of list's save button */}
+        <ScrollableImageEditor {...siProps} onChange={onChange} />
+      </div>
+    </FieldContainer>
+  )
+}

--- a/packages/public-cms/migrations/20250225042655_add_scrollable_image_list/migration.sql
+++ b/packages/public-cms/migrations/20250225042655_add_scrollable_image_list/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "ScrollableImage" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL DEFAULT '',
+    "editorState" JSONB DEFAULT '{"captions":[],"imgObjs":[],"customCss":"\n  /* 給報導者文章頁使用 */\n  /* 將元件往上移動，使其與上一個區塊連接在一起。*/\n  /* 刪除下方註解即可使用。 */\n  /*\n  .storytelling-react-scrollable-image-container {\n    margin-top: -40px;\n  }\n  */\n\n  /* 給報導者文章頁使用 */\n  /* 將元件向左移動，撐滿文章頁 */\n  /* 刪除下方註解即可使用。 */\n  /*\n  @media (max-width: 767px) {\n    .storytelling-react-scrollable-image-container {\n      margin-left: -3.4vw;\n    }\n  }\n\n  @media (min-width: 768px) and (max-width: 1023px) {\n    .storytelling-react-scrollable-image-container {\n      margin-left: calc((100vw - 512px)/2 * -1);\n    }\n  }\n\n  @media (min-width: 1024px) and (max-width: 1439px) {\n    .storytelling-react-scrollable-image-container {\n      margin-left: calc((100vw - 550px)/2 * -1);\n    }\n  }\n\n  @media (min-width: 1440px) {\n    .storytelling-react-scrollable-image-container {\n      margin-left: calc((100vw - 730px)/2 * -1);\n    }\n  }\n  */\n\n  /* 給少年報導者文章頁使用 */\n  /* 將元件向左移動，撐滿文章頁 */\n  /* 刪除下方註解即可使用。 */\n  /*\n  @media (max-width: 767px) {\n    .storytelling-react-scrollable-image-container {\n      margin-left: -5vw;\n    }\n  }\n\n  @media (min-width: 768px) {\n    .storytelling-react-scrollable-image-container {\n      margin-left: calc((100vw - 700px)/2 * -1);\n    }\n  }\n  */\n","className":"storytelling-react-scrollable-image-container"}',
+
+    CONSTRAINT "ScrollableImage_pkey" PRIMARY KEY ("id")
+);

--- a/packages/public-cms/package.json
+++ b/packages/public-cms/package.json
@@ -20,6 +20,7 @@
     "@keystone-6/core": "5.2.0",
     "@story-telling-reporter/draft-editor": "^2.1.0",
     "@story-telling-reporter/react-embed-code-generator": "^2.2.10",
+    "@story-telling-reporter/react-scrollable-image": "^0.3.4",
     "@story-telling-reporter/react-scrollable-video": "^3.0.1",
     "@story-telling-reporter/react-three-story-controls": "^2.2.1",
     "@types/clean-css": "^4.2.11",

--- a/packages/public-cms/schema.graphql
+++ b/packages/public-cms/schema.graphql
@@ -462,6 +462,45 @@ input ScrollableVideoCreateInput {
   created_by: UserRelateToOneForCreateInput
 }
 
+type ScrollableImage {
+  id: ID!
+  name: String
+  editorState: JSON
+  embedCode: String
+}
+
+input ScrollableImageWhereUniqueInput {
+  id: ID
+}
+
+input ScrollableImageWhereInput {
+  AND: [ScrollableImageWhereInput!]
+  OR: [ScrollableImageWhereInput!]
+  NOT: [ScrollableImageWhereInput!]
+  id: IDFilter
+  name: StringFilter
+}
+
+input ScrollableImageOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+}
+
+input ScrollableImageUpdateInput {
+  name: String
+  editorState: JSON
+}
+
+input ScrollableImageUpdateArgs {
+  where: ScrollableImageWhereUniqueInput!
+  data: ScrollableImageUpdateInput!
+}
+
+input ScrollableImageCreateInput {
+  name: String
+  editorState: JSON
+}
+
 type ScrollableThreeModel {
   id: ID!
   name: String
@@ -553,6 +592,12 @@ type Mutation {
   updateScrollableVideos(data: [ScrollableVideoUpdateArgs!]!): [ScrollableVideo]
   deleteScrollableVideo(where: ScrollableVideoWhereUniqueInput!): ScrollableVideo
   deleteScrollableVideos(where: [ScrollableVideoWhereUniqueInput!]!): [ScrollableVideo]
+  createScrollableImage(data: ScrollableImageCreateInput!): ScrollableImage
+  createScrollableImages(data: [ScrollableImageCreateInput!]!): [ScrollableImage]
+  updateScrollableImage(where: ScrollableImageWhereUniqueInput!, data: ScrollableImageUpdateInput!): ScrollableImage
+  updateScrollableImages(data: [ScrollableImageUpdateArgs!]!): [ScrollableImage]
+  deleteScrollableImage(where: ScrollableImageWhereUniqueInput!): ScrollableImage
+  deleteScrollableImages(where: [ScrollableImageWhereUniqueInput!]!): [ScrollableImage]
   createScrollableThreeModel(data: ScrollableThreeModelCreateInput!): ScrollableThreeModel
   createScrollableThreeModels(data: [ScrollableThreeModelCreateInput!]!): [ScrollableThreeModel]
   updateScrollableThreeModel(where: ScrollableThreeModelWhereUniqueInput!, data: ScrollableThreeModelUpdateInput!): ScrollableThreeModel
@@ -601,6 +646,9 @@ type Query {
   scrollableVideos(where: ScrollableVideoWhereInput! = {}, orderBy: [ScrollableVideoOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ScrollableVideoWhereUniqueInput): [ScrollableVideo!]
   scrollableVideo(where: ScrollableVideoWhereUniqueInput!): ScrollableVideo
   scrollableVideosCount(where: ScrollableVideoWhereInput! = {}): Int
+  scrollableImages(where: ScrollableImageWhereInput! = {}, orderBy: [ScrollableImageOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ScrollableImageWhereUniqueInput): [ScrollableImage!]
+  scrollableImage(where: ScrollableImageWhereUniqueInput!): ScrollableImage
+  scrollableImagesCount(where: ScrollableImageWhereInput! = {}): Int
   scrollableThreeModels(where: ScrollableThreeModelWhereInput! = {}, orderBy: [ScrollableThreeModelOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ScrollableThreeModelWhereUniqueInput): [ScrollableThreeModel!]
   scrollableThreeModel(where: ScrollableThreeModelWhereUniqueInput!): ScrollableThreeModel
   scrollableThreeModelsCount(where: ScrollableThreeModelWhereInput! = {}): Int

--- a/packages/public-cms/schema.prisma
+++ b/packages/public-cms/schema.prisma
@@ -97,6 +97,12 @@ model ScrollableVideo {
   @@index([created_byId])
 }
 
+model ScrollableImage {
+  id          Int    @id @default(autoincrement())
+  name        String @default("")
+  editorState Json?  @default("{\"captions\":[],\"imgObjs\":[],\"customCss\":\"\\n  /* 給報導者文章頁使用 */\\n  /* 將元件往上移動，使其與上一個區塊連接在一起。*/\\n  /* 刪除下方註解即可使用。 */\\n  /*\\n  .storytelling-react-scrollable-image-container {\\n    margin-top: -40px;\\n  }\\n  */\\n\\n  /* 給報導者文章頁使用 */\\n  /* 將元件向左移動，撐滿文章頁 */\\n  /* 刪除下方註解即可使用。 */\\n  /*\\n  @media (max-width: 767px) {\\n    .storytelling-react-scrollable-image-container {\\n      margin-left: -3.4vw;\\n    }\\n  }\\n\\n  @media (min-width: 768px) and (max-width: 1023px) {\\n    .storytelling-react-scrollable-image-container {\\n      margin-left: calc((100vw - 512px)/2 * -1);\\n    }\\n  }\\n\\n  @media (min-width: 1024px) and (max-width: 1439px) {\\n    .storytelling-react-scrollable-image-container {\\n      margin-left: calc((100vw - 550px)/2 * -1);\\n    }\\n  }\\n\\n  @media (min-width: 1440px) {\\n    .storytelling-react-scrollable-image-container {\\n      margin-left: calc((100vw - 730px)/2 * -1);\\n    }\\n  }\\n  */\\n\\n  /* 給少年報導者文章頁使用 */\\n  /* 將元件向左移動，撐滿文章頁 */\\n  /* 刪除下方註解即可使用。 */\\n  /*\\n  @media (max-width: 767px) {\\n    .storytelling-react-scrollable-image-container {\\n      margin-left: -5vw;\\n    }\\n  }\\n\\n  @media (min-width: 768px) {\\n    .storytelling-react-scrollable-image-container {\\n      margin-left: calc((100vw - 700px)/2 * -1);\\n    }\\n  }\\n  */\\n\",\"className\":\"storytelling-react-scrollable-image-container\"}")
+}
+
 model ScrollableThreeModel {
   id               Int    @id @default(autoincrement())
   name             String @default("")


### PR DESCRIPTION
### 任務說明
在 `packages/public-cms` 使用新版的橫著滾吧！`@story-telling-reporter/react-scrollable-image` 元件。
新版橫著滾吧！元件提供以下新的功能：
1. 所見即所得的編輯器
2. 可以在照片上輸入文字框
3. 可以設定元件的高度 `width`、最大高度 `max-width` 和最小高度 `min-width`
4. 可以設定客製化 css