### PR TITLE
Fix build failures because of @keystone-6/core@5.2.0 incompatible with next@13.5.11

### DIFF
--- a/packages/cms/lists/views/scrollable-three-model/index.tsx
+++ b/packages/cms/lists/views/scrollable-three-model/index.tsx
@@ -38,7 +38,7 @@ export const Field = ({
     // Keystone uses Webpack and its related loaders, such as babel-loader, to transpile the source codes (this file).
     // But, Webpack cannot handle the import well.
     // The following is a workaround to solve this error.
-    const {CameraHelper} = require('@story-telling-reporter/react-three-story-controls')  // eslint-disable-line
+    const {CameraHelper} = require('@story-telling-reporter/react-three-story-controls/lib/esm/index')  // eslint-disable-line
     CameraHelperRef.current =
       CameraHelper as React.ComponentType<CameraHelperProps>
 

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@keystone-6/auth": "7.0.0",
-    "@keystone-6/core": "5.2.0",
+    "@keystone-6/core": "5.8.0",
     "@story-telling-reporter/draft-editor": "^2.1.2",
     "@story-telling-reporter/react-embed-code-generator": "^2.2.11",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -442,21 +442,7 @@ input StringNullableFilter {
   startsWith: String
   endsWith: String
   mode: QueryMode
-  not: NestedStringNullableFilter
-}
-
-input NestedStringNullableFilter {
-  equals: String
-  in: [String!]
-  notIn: [String!]
-  lt: String
-  lte: String
-  gt: String
-  gte: String
-  contains: String
-  startsWith: String
-  endsWith: String
-  not: NestedStringNullableFilter
+  not: StringNullableFilter
 }
 
 input KaraokeOrderByInput {

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -48,11 +48,11 @@ model Video {
 model Photo {
   id                    Int       @id @default(autoincrement())
   name                  String    @default("")
+  imageFile_id          String?
   imageFile_filesize    Int?
-  imageFile_extension   String?
   imageFile_width       Int?
   imageFile_height      Int?
-  imageFile_id          String?
+  imageFile_extension   String?
   createdAt             DateTime? @default(now())
   updatedAt             DateTime? @updatedAt
   from_Video_coverPhoto Video[]   @relation("Video_coverPhoto")

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/draft-editor",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -22,7 +22,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@keystone-6/core": "5.2.0",
+    "@keystone-6/core": "5.8.0",
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",

--- a/packages/public-cms/lists/views/scrollable-three-model/index.tsx
+++ b/packages/public-cms/lists/views/scrollable-three-model/index.tsx
@@ -51,7 +51,7 @@ export const Field = ({
     // Keystone uses Webpack and its related loaders, such as babel-loader, to transpile the source codes (this file).
     // But, Webpack cannot handle the import well.
     // The following is a workaround to solve this error.
-    const {CameraHelper} = require('@story-telling-reporter/react-three-story-controls')  // eslint-disable-line
+    const {CameraHelper} = require('@story-telling-reporter/react-three-story-controls/lib/esm/index')  // eslint-disable-line
     CameraHelperRef.current =
       CameraHelper as React.ComponentType<CameraHelperProps>
 

--- a/packages/public-cms/package.json
+++ b/packages/public-cms/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@keystone-6/auth": "7.0.0",
-    "@keystone-6/core": "5.2.0",
+    "@keystone-6/core": "5.8.0",
     "@story-telling-reporter/draft-editor": "^2.1.2",
     "@story-telling-reporter/react-embed-code-generator": "^2.2.11",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",

--- a/packages/public-cms/schema.prisma
+++ b/packages/public-cms/schema.prisma
@@ -58,11 +58,11 @@ model Video {
 model Photo {
   id                  Int       @id @default(autoincrement())
   name                String    @default("")
+  imageFile_id        String?
   imageFile_filesize  Int?
-  imageFile_extension String?
   imageFile_width     Int?
   imageFile_height    Int?
-  imageFile_id        String?
+  imageFile_extension String?
   description         String    @default("")
   created_at          DateTime? @default(now())
   updated_at          DateTime? @updatedAt


### PR DESCRIPTION
### PR 說明
PR https://github.com/lab-reporter/storytelling-monorepo/pull/65 將 next 升級到 13.5.11 後，會遇到 @keystone-6/core 無法順利 `keystone build` 的問題，相關訊息請見 https://github.com/keystonejs/keystone/pull/8788 。

因此，我們必須將 monorepo 中的 @keystone-6/core 升級到  > 5.5.1 的版本，才會解決 `keystone build` 無法順利執行完畢的問題。