### PR TITLE
fix(subtitled-audio,ui-toolkit): cdn can not respond sound.svg correctly

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -19,7 +19,7 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.8.0",
     "@story-telling-reporter/draft-editor": "^2.1.2",
-    "@story-telling-reporter/react-embed-code-generator": "^2.2.12",
+    "@story-telling-reporter/react-embed-code-generator": "^2.2.13",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",
     "@story-telling-reporter/react-scrollable-video": "^3.0.1",
     "@story-telling-reporter/react-three-story-controls": "^2.2.3",

--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-embed-code-generator",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -32,7 +32,7 @@
     "@story-telling-reporter/react-scroll-to-audio": "^3.0.3",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",
     "@story-telling-reporter/react-scrollable-video": "^3.0.1",
-    "@story-telling-reporter/react-subtitled-audio": "^1.1.3",
+    "@story-telling-reporter/react-subtitled-audio": "^1.1.4",
     "@story-telling-reporter/react-three-story-controls": "^2.2.3",
     "lodash": "^4.17.21",
     "serialize-javascript": "^6.0.0"

--- a/packages/subtitled-audio/package.json
+++ b/packages/subtitled-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-subtitled-audio",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/subtitled-audio/src/kids/icons.js
+++ b/packages/subtitled-audio/src/kids/icons.js
@@ -1,7 +1,7 @@
 import React/* eslint-disable-line */ from 'react'
 
 const iconURLPath =
-  'https://www.unpkg.com/@story-telling-reporter/react-subtitled-audio/public/icons/kids'
+  'https://storytelling-storage.twreporter.org/npm/@story-telling-reporter/react-subtitled-audio/public/icons/kids'
 
 export function SoundIcon({ className, onClick, style }) {
   return (

--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-ui-toolkit",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/ui-toolkit/src/kids/icons.tsx
+++ b/packages/ui-toolkit/src/kids/icons.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const iconURLPath =
-  'https://www.unpkg.com/@story-telling-reporter/react-ui-toolkit/public/icons/kids'
+  'https://storytelling-storage.twreporter.org/npm/@story-telling-reporter/react-ui-toolkit/public/icons/kids'
 
 type IconProps = {
   className?: string


### PR DESCRIPTION
### Bug 說明
unpkg.com cdn 在處理某些 url 時，會遇到非預期的錯誤。
例如：
- https://www.unpkg.com/@story-telling-reporter/react-subtitled-audio/public/icons/kids/sound.svg
- https://www.unpkg.com/@story-telling-reporter/react-ui-toolkit/public/icons/kids/sound.svg
上述兩個 url，unpkg 會回傳 500 response。

但如果不是拿 `sound.svg` 而是改拿 `mute.svg`，
例如：
- https://www.unpkg.com/@story-telling-reporter/react-subtitled-audio/public/icons/kids/mute.svg
- https://www.unpkg.com/@story-telling-reporter/react-ui-toolkit/public/icons/kids/mute.svg
則 unpkg 就會正常回覆檔案。

為了避免 unpkg 時好時壞的問題，我們改將 assets 上傳到自己的 storage ( https://storytelling-storage.twreporter.org )。 
