### PR TITLE
fix(cms,public-cms): change iframe src from absolute URL to root-relative path

### DIFF
--- a/packages/cms/admin/pages/iframe/dual-channel.tsx
+++ b/packages/cms/admin/pages/iframe/dual-channel.tsx
@@ -7,7 +7,7 @@ export default function CustomPage() {
     <PageContainer header={<Heading type="h3">左右互搏</Heading>}>
       <div style={{ display: 'flex', width: '100%', height: '100%' }}>
         <iframe
-          src="https://lab-storytelling.twreporter.org/dual-channel"
+          src="/dual-channel"
           width="100%"
           height="100%"
           style={{ flexGrow: 1, border: 'none' }}

--- a/packages/cms/admin/pages/iframe/scrollable-image.tsx
+++ b/packages/cms/admin/pages/iframe/scrollable-image.tsx
@@ -7,7 +7,7 @@ export default function CustomPage() {
     <PageContainer header={<Heading type="h3">橫著滾吧！</Heading>}>
       <div style={{ display: 'flex', width: '100%', height: '100%' }}>
         <iframe
-          src="https://lab-storytelling.twreporter.org/scrollable-image"
+          src="/scrollable-image"
           width="100%"
           height="100%"
           style={{ flexGrow: 1, border: 'none' }}

--- a/packages/cms/admin/pages/iframe/timeline.tsx
+++ b/packages/cms/admin/pages/iframe/timeline.tsx
@@ -7,7 +7,7 @@ export default function CustomPage() {
     <PageContainer header={<Heading type="h3">大事記</Heading>}>
       <div style={{ display: 'flex', width: '100%', height: '100%' }}>
         <iframe
-          src="https://lab-storytelling.twreporter.org/timeline"
+          src="/timeline"
           width="100%"
           height="100%"
           style={{ flexGrow: 1, border: 'none' }}

--- a/packages/cms/admin/pages/iframe/zoom-in.tsx
+++ b/packages/cms/admin/pages/iframe/zoom-in.tsx
@@ -7,7 +7,7 @@ export default function CustomPage() {
     <PageContainer header={<Heading type="h3">大圖點我</Heading>}>
       <div style={{ display: 'flex', width: '100%', height: '100%' }}>
         <iframe
-          src="https://lab-storytelling.twreporter.org/zoom-in"
+          src="/zoom-in"
           width="100%"
           height="100%"
           style={{ flexGrow: 1, border: 'none' }}

--- a/packages/public-cms/admin/pages/iframe/dual-channel.tsx
+++ b/packages/public-cms/admin/pages/iframe/dual-channel.tsx
@@ -7,7 +7,7 @@ export default function CustomPage() {
     <PageContainer header={<Heading type="h3">左右互搏</Heading>}>
       <div style={{ display: 'flex', width: '100%', height: '100%' }}>
         <iframe
-          src="https://lab-storytelling.twreporter.org/dual-channel"
+          src="/dual-channel"
           width="100%"
           height="100%"
           style={{ flexGrow: 1, border: 'none' }}

--- a/packages/public-cms/admin/pages/iframe/scrollable-image.tsx
+++ b/packages/public-cms/admin/pages/iframe/scrollable-image.tsx
@@ -7,7 +7,7 @@ export default function CustomPage() {
     <PageContainer header={<Heading type="h3">橫著滾吧！</Heading>}>
       <div style={{ display: 'flex', width: '100%', height: '100%' }}>
         <iframe
-          src="https://lab-storytelling.twreporter.org/scrollable-image"
+          src="/scrollable-image"
           width="100%"
           height="100%"
           style={{ flexGrow: 1, border: 'none' }}

--- a/packages/public-cms/admin/pages/iframe/timeline.tsx
+++ b/packages/public-cms/admin/pages/iframe/timeline.tsx
@@ -7,7 +7,7 @@ export default function CustomPage() {
     <PageContainer header={<Heading type="h3">大事記</Heading>}>
       <div style={{ display: 'flex', width: '100%', height: '100%' }}>
         <iframe
-          src="https://lab-storytelling.twreporter.org/timeline"
+          src="/timeline"
           width="100%"
           height="100%"
           style={{ flexGrow: 1, border: 'none' }}

--- a/packages/public-cms/admin/pages/iframe/zoom-in.tsx
+++ b/packages/public-cms/admin/pages/iframe/zoom-in.tsx
@@ -7,7 +7,7 @@ export default function CustomPage() {
     <PageContainer header={<Heading type="h3">大圖點我</Heading>}>
       <div style={{ display: 'flex', width: '100%', height: '100%' }}>
         <iframe
-          src="https://lab-storytelling.twreporter.org/zoom-in"
+          src="/zoom-in"
           width="100%"
           height="100%"
           style={{ flexGrow: 1, border: 'none' }}


### PR DESCRIPTION
### Bug 回報
見[ Slack 訊息](https://twreporter.slack.com/archives/C09N6TNN7/p1755171904633049)。

### Bug 說明
在 `https://storytelling-cms.twreporter.org` 鑲嵌 `https://lab-storytelling.twreporter.org/timeline` 網址，在新版的 chromium 上會遇到 cross origin 的問題，導致無法一鍵複製 embed code。

瀏覽器顯示的錯誤如下：
`
NotAllowedError: Failed to execute 'writeText' on 'Clipboard': The Clipboard API has been blocked because of a permissions policy applied to the current document. See https://crbug.com/414348233 for more details.
`

### 修正方式
將 iframe 的網址從絕對路徑改成相對路徑，確保 iframe 網址與 storytelling-cms 的網址在同一個 sub-domain 底下。