### PR TITLE
fix(cms): add missing ACL protection

### DIFF
--- a/packages/cms/lists/audio.ts
+++ b/packages/cms/lists/audio.ts
@@ -67,12 +67,7 @@ const listConfigurations = list({
   access: {
     operation: {
       query: allowAllRoles(),
-      create: allowRoles([
-        RoleEnum.Owner,
-        RoleEnum.Admin,
-        RoleEnum.Editor,
-        RoleEnum.Contributor,
-      ]),
+      create: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
       update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
       delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
     },

--- a/packages/cms/lists/dual-slides.ts
+++ b/packages/cms/lists/dual-slides.ts
@@ -8,6 +8,11 @@ import {
   json,
   virtual,
 } from '@keystone-6/core/fields'
+import {
+  allowAllRoles,
+  allowRoles,
+  RoleEnum,
+} from './utils/access-control-list'
 
 const embedCodeWebpackAssets = embedCodeGen.loadWebpackAssets()
 
@@ -82,7 +87,15 @@ const listConfigurations = list({
     labelField: 'name',
   },
 
-  access: () => true,
+  access: {
+    operation: {
+      query: allowAllRoles(),
+      create: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+    },
+  },
+
   hooks: {},
 })
 

--- a/packages/cms/lists/karaoke.ts
+++ b/packages/cms/lists/karaoke.ts
@@ -2,6 +2,11 @@ import config from '../config'
 import { buildKaraokeEmbedCode } from '@story-telling-reporter/react-embed-code-generator'
 import { list, graphql } from '@keystone-6/core'
 import { checkbox, text, file, virtual, select } from '@keystone-6/core/fields'
+import {
+  allowAllRoles,
+  allowRoles,
+  RoleEnum,
+} from './utils/access-control-list'
 
 const listConfigurations = list({
   fields: {
@@ -122,7 +127,15 @@ const listConfigurations = list({
     labelField: 'name',
   },
 
-  access: () => true,
+  access: {
+    operation: {
+      query: allowAllRoles(),
+      create: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+    },
+  },
+
   hooks: {},
 })
 

--- a/packages/cms/lists/photo.ts
+++ b/packages/cms/lists/photo.ts
@@ -126,12 +126,7 @@ const listConfigurations = list({
   access: {
     operation: {
       query: allowAllRoles(),
-      create: allowRoles([
-        RoleEnum.Owner,
-        RoleEnum.Admin,
-        RoleEnum.Editor,
-        RoleEnum.Contributor,
-      ]),
+      create: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
       update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
       delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
     },

--- a/packages/cms/lists/scroll-to-audio.ts
+++ b/packages/cms/lists/scroll-to-audio.ts
@@ -1,6 +1,11 @@
 import { buildScrollToAudioEmbedCode } from '@story-telling-reporter/react-embed-code-generator'
 import { list, graphql } from '@keystone-6/core'
 import { text, virtual } from '@keystone-6/core/fields'
+import {
+  allowAllRoles,
+  allowRoles,
+  RoleEnum,
+} from './utils/access-control-list'
 
 const hintId = 'muted-hint-id'
 
@@ -126,7 +131,15 @@ const listConfigurations = list({
     labelField: 'name',
   },
 
-  access: () => true,
+  access: {
+    operation: {
+      query: allowAllRoles(),
+      create: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+    },
+  },
+
   hooks: {},
 })
 

--- a/packages/cms/lists/scrollable-image.ts
+++ b/packages/cms/lists/scrollable-image.ts
@@ -2,6 +2,11 @@ import { ScrollableImageEditorProps } from '@story-telling-reporter/react-scroll
 import { buildScrollableImageEmbedCode } from '@story-telling-reporter/react-embed-code-generator'
 import { graphql, list } from '@keystone-6/core'
 import { text, json, virtual } from '@keystone-6/core/fields'
+import {
+  allowAllRoles,
+  allowRoles,
+  RoleEnum,
+} from './utils/access-control-list'
 
 const className = 'storytelling-react-scrollable-image-container'
 const customCss = `
@@ -123,7 +128,15 @@ const listConfigurations = list({
     labelField: 'name',
   },
 
-  access: () => true,
+  access: {
+    operation: {
+      query: allowAllRoles(),
+      create: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+    },
+  },
+
   hooks: {},
 })
 

--- a/packages/cms/lists/scrollable-three-model.ts
+++ b/packages/cms/lists/scrollable-three-model.ts
@@ -2,6 +2,11 @@ import { graphql, list } from '@keystone-6/core'
 import { text, json, virtual } from '@keystone-6/core/fields'
 import { buildScrollableThreeModelEmbedCode } from '@story-telling-reporter/react-embed-code-generator'
 import { ScrollableThreeModelProps } from '@story-telling-reporter/react-three-story-controls'
+import {
+  allowAllRoles,
+  allowRoles,
+  RoleEnum,
+} from './utils/access-control-list'
 
 const listConfigurations = list({
   fields: {
@@ -67,7 +72,15 @@ const listConfigurations = list({
     labelField: 'name',
   },
 
-  access: () => true,
+  access: {
+    operation: {
+      query: allowAllRoles(),
+      create: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+    },
+  },
+
   hooks: {
     resolveInput: ({ inputData, item, resolvedData }) => {
       const modelSrc = inputData?.modelSrc

--- a/packages/cms/lists/scrollable-video.ts
+++ b/packages/cms/lists/scrollable-video.ts
@@ -9,6 +9,11 @@ import { customAlphabet } from 'nanoid'
 import CleanCss from 'clean-css'
 import postcss from 'postcss'
 import postcssNesting from 'postcss-nesting'
+import {
+  allowAllRoles,
+  allowRoles,
+  RoleEnum,
+} from './utils/access-control-list'
 
 const nanoid = customAlphabet('abcdefghijklmnopq', 10)
 
@@ -227,7 +232,15 @@ const listConfigurations = list({
     labelField: 'name',
   },
 
-  access: () => true,
+  access: {
+    operation: {
+      query: allowAllRoles(),
+      create: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+    },
+  },
+
   hooks: {
     resolveInput: ({ inputData, item, resolvedData }) => {
       const videoSrc = inputData?.videoSrc

--- a/packages/cms/lists/subtitled-audio.ts
+++ b/packages/cms/lists/subtitled-audio.ts
@@ -2,6 +2,11 @@ import config from '../config'
 import { buildSubtitledAudioEmbedCode } from '@story-telling-reporter/react-embed-code-generator'
 import { list, graphql } from '@keystone-6/core'
 import { text, file, virtual } from '@keystone-6/core/fields'
+import {
+  allowAllRoles,
+  allowRoles,
+  RoleEnum,
+} from './utils/access-control-list'
 
 const listConfigurations = list({
   fields: {
@@ -66,7 +71,15 @@ const listConfigurations = list({
     labelField: 'name',
   },
 
-  access: () => true,
+  access: {
+    operation: {
+      query: allowAllRoles(),
+      create: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+    },
+  },
+
   hooks: {},
 })
 

--- a/packages/cms/lists/three-model.ts
+++ b/packages/cms/lists/three-model.ts
@@ -51,12 +51,7 @@ const listConfigurations = list({
   access: {
     operation: {
       query: allowAllRoles(),
-      create: allowRoles([
-        RoleEnum.Owner,
-        RoleEnum.Admin,
-        RoleEnum.Editor,
-        RoleEnum.Contributor,
-      ]),
+      create: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
       update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
       delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
     },

--- a/packages/cms/lists/user.ts
+++ b/packages/cms/lists/user.ts
@@ -35,24 +35,8 @@ const listConfigurations = list({
           value: RoleEnum.Admin,
         },
         {
-          label: RoleEnum.Developer,
-          value: RoleEnum.Developer,
-        },
-        {
           label: RoleEnum.Editor,
           value: RoleEnum.Editor,
-        },
-        {
-          label: RoleEnum.Contributor,
-          value: RoleEnum.Contributor,
-        },
-        {
-          label: RoleEnum.FrontendHeadlessAccount,
-          value: RoleEnum.FrontendHeadlessAccount,
-        },
-        {
-          label: RoleEnum.PreviewHeadlessAccount,
-          value: RoleEnum.PreviewHeadlessAccount,
         },
       ],
       validation: { isRequired: true },

--- a/packages/cms/lists/utils/access-control-list.ts
+++ b/packages/cms/lists/utils/access-control-list.ts
@@ -9,11 +9,7 @@ type Session = {
 export const RoleEnum = {
   Owner: 'owner',
   Admin: 'admin',
-  Developer: 'developer',
   Editor: 'editor',
-  Contributor: 'contributor',
-  FrontendHeadlessAccount: 'frontend_headless_account',
-  PreviewHeadlessAccount: 'preview_headless_account',
 }
 
 export const allowRoles = (roles: string[]) => {
@@ -35,15 +31,7 @@ export const allowRoles = (roles: string[]) => {
 }
 
 export const allowAllRoles = () => {
-  const roles = [
-    RoleEnum.Owner,
-    RoleEnum.Admin,
-    RoleEnum.Developer,
-    RoleEnum.Editor,
-    RoleEnum.Contributor,
-    RoleEnum.FrontendHeadlessAccount,
-    RoleEnum.PreviewHeadlessAccount,
-  ]
+  const roles = [RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]
   return allowRoles(roles)
 }
 

--- a/packages/cms/lists/video.ts
+++ b/packages/cms/lists/video.ts
@@ -73,12 +73,7 @@ const listConfigurations = list({
   access: {
     operation: {
       query: allowAllRoles(),
-      create: allowRoles([
-        RoleEnum.Owner,
-        RoleEnum.Admin,
-        RoleEnum.Editor,
-        RoleEnum.Contributor,
-      ]),
+      create: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
       update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
       delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
     },


### PR DESCRIPTION
### PR description
Previously the CMS GQL API lacked proper ACL checks, allowing unauthorized access.
This commit enforces ACL protection to restrict access to authorized users only.