### PR TITLE
refactor(scrollable-video): adjust scrollable video trigger start threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "packageManager": "yarn@1.22.19"
 }

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -19,7 +19,7 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.8.0",
     "@story-telling-reporter/draft-editor": "^2.1.2",
-    "@story-telling-reporter/react-embed-code-generator": "^2.2.14",
+    "@story-telling-reporter/react-embed-code-generator": "^2.2.16",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",
     "@story-telling-reporter/react-scrollable-video": "^3.0.1",
     "@story-telling-reporter/react-three-story-controls": "^2.2.3",

--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-embed-code-generator",
-  "version": "2.2.15",
+  "version": "2.2.16",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -32,7 +32,7 @@
     "@story-telling-reporter/react-puzzle-photo-infra": "^1.0.0",
     "@story-telling-reporter/react-scroll-to-audio": "^3.0.3",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",
-    "@story-telling-reporter/react-scrollable-video": "^3.0.1",
+    "@story-telling-reporter/react-scrollable-video": "^3.0.2",
     "@story-telling-reporter/react-subtitled-audio": "^1.1.4",
     "@story-telling-reporter/react-three-story-controls": "^2.2.3",
     "lodash": "^4.17.21",

--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -29,13 +29,14 @@
   "license": "MIT",
   "dependencies": {
     "@story-telling-reporter/react-karaoke": "^1.0.3",
+    "@story-telling-reporter/react-puzzle-photo-infra": "^1.0.0",
     "@story-telling-reporter/react-scroll-to-audio": "^3.0.3",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",
     "@story-telling-reporter/react-scrollable-video": "^3.0.1",
     "@story-telling-reporter/react-subtitled-audio": "^1.1.4",
     "@story-telling-reporter/react-three-story-controls": "^2.2.3",
-    "@story-telling-reporter/react-puzzle-photo-infra": "^1.0.0",
     "lodash": "^4.17.21",
+    "regenerator-runtime": "^0.14.1",
     "serialize-javascript": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/scrollable-video/package.json
+++ b/packages/scrollable-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-scrollable-video",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/packages/scrollable-video/src/v2/index.tsx
+++ b/packages/scrollable-video/src/v2/index.tsx
@@ -189,7 +189,7 @@ export function ScrollableVideo({
       scrollTriggerInstance.current = ScrollTrigger.create({
         markers: debugMode,
         trigger: scrollTriggerRef.current,
-        start: 'top 50%',
+        start: 'top 100%',
         end: 'bottom 50%',
         scroller: scrollerRef?.current || window,
         onUpdate: ({ progress }: { progress: number }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7382,15 +7382,6 @@ fp-ts@2.16.0:
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.16.0.tgz#64e03314dfc1c7ce5e975d3496ac14bc3eb7f92e"
   integrity sha512-bLq+KgbiXdTEoT1zcARrWEpa5z6A/8b7PcDW7Gef3NSisQ+VS7ll2Xbf1E+xsgik0rWub/8u0qP/iTTjj+PhxQ==
 
-framer-motion@^12.6.3:
-  version "12.9.4"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-12.9.4.tgz#c3091d77d6e84d1105549c40e4d7890b60f1ffb6"
-  integrity sha512-yaeGDmGQ3eCQEwZ95/pRQMaSh/Q4E2CK6JYOclG/PdjyQad0MULJ+JFVV8911Fl5a6tF6o0wgW8Dpl5Qx4Adjg==
-  dependencies:
-    motion-dom "^12.9.4"
-    motion-utils "^12.9.4"
-    tslib "^2.4.0"
-
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -9256,18 +9247,6 @@ mongoose@6.11.2:
     ms "2.1.3"
     sift "16.0.1"
 
-motion-dom@^12.9.4:
-  version "12.9.4"
-  resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-12.9.4.tgz#9de06ab408effc73877309cf27813442501ec0ef"
-  integrity sha512-25TWkQPj5I18m+qVjXGtCsxboY11DaRC5HMjd29tHKExazW4Zf4XtAagBdLpyKsVuAxEQ6cx5/E4AB21PFpLnQ==
-  dependencies:
-    motion-utils "^12.9.4"
-
-motion-utils@^12.9.4:
-  version "12.9.4"
-  resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-12.9.4.tgz#9d5a45a19971e20059911526d7af2217c5158fa2"
-  integrity sha512-BW3I65zeM76CMsfh3kHid9ansEJk9Qvl+K5cu4DVHKGsI52n76OJ4z2CUJUV+Mn3uEP9k1JJA3tClG0ggSrRcg==
-
 mpath@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.9.0.tgz#0c122fe107846e31fc58c75b09c35514b3871904"
@@ -10485,6 +10464,11 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
+
+regenerator-runtime@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regexp.prototype.flags@^1.5.3:
   version "1.5.4"


### PR DESCRIPTION
### Description

  - Delay ScrollTrigger start to top 100% so the animation waits until the section fully reaches the viewport bottom, reducing premature playback on short screens
    (packages/scrollable-video/src/v2/index.tsx).
  - Release @story-telling-reporter/react-scrollable-video@3.0.2 and wire it into the embed code generator + CMS so downstream bundles pick up the fixed trigger
    (packages/scrollable-video/package.json, packages/embed-code-generator/package.json, packages/cms/package.json).
  - Add regenerator-runtime to the embed code generator to ensure transpiled async helpers run inside legacy embeds (packages/embed-code-generator/package.json).
  - Pin the workspace to yarn@1.22.19 via packageManager metadata and refresh yarn.lock for deterministic installs (package.json, yarn.lock).