### PR TITLE
fix: support scroll-to-audio inside fullscreen editor

### DIFF
--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-embed-code-generator",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
   "dependencies": {
     "@story-telling-reporter/react-karaoke": "^1.0.3",
     "@story-telling-reporter/react-puzzle-photo-infra": "^1.0.0",
-    "@story-telling-reporter/react-scroll-to-audio": "^3.0.3",
+    "@story-telling-reporter/react-scroll-to-audio": "^3.1.0",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",
     "@story-telling-reporter/react-scrollable-video": "^3.0.2",
     "@story-telling-reporter/react-subtitled-audio": "^1.1.4",

--- a/packages/embed-code-generator/src/build-code/index.js
+++ b/packages/embed-code-generator/src/build-code/index.js
@@ -60,7 +60,55 @@ export function buildScrollToAudioEmbedCode(
   if (bottomEntryPointOnly) {
     return buildBottomEntryPointStaticMarkup({ id: data?.id })
   }
-  return buildEmbedCode(data, pkgNames.scrollToAudio, ScrollToAudio)
+
+  const uuid = uuidv4()
+  const dataWithUuid = { ...data, uuid }
+
+  const sheet = new ServerStyleSheet()
+  let jsx = ''
+  let styleTags = ''
+  try {
+    jsx = ReactDOMServer.renderToStaticMarkup(
+      sheet.collectStyles(<ScrollToAudio {...data} />)
+    )
+    styleTags = sheet.getStyleTags()
+  } finally {
+    sheet.seal()
+  }
+
+  const pkgName = pkgNames.scrollToAudio
+
+  return `
+    ${styleTags}
+    <div id="${uuid}">${jsx}</div>
+    <script>
+      (function() {
+        var namespace = '@story-telling-reporter/react-embed-code-generator@${
+          manifest.version
+        }';
+        var pkg = '${pkgName}';
+        if (typeof window != 'undefined') {
+          if (!window.hasOwnProperty(namespace)) {
+            window[namespace] = {};
+          }
+          if (window[namespace] && !window[namespace].hasOwnProperty(pkg)) {
+            window[namespace][pkg] = [];
+          }
+          if (Array.isArray(window[namespace][pkg])) {
+            var embedEl = document.getElementById('${uuid}');
+            var scrollerEl = embedEl && embedEl.closest('.editor-fullscreen-scroller');
+            var scrollerRef = scrollerEl ? { current: scrollerEl } : undefined;
+            var data = ${serialize(dataWithUuid)};
+            data.scrollerRef = scrollerRef;
+            window[namespace][pkg].push(data);
+          }
+        }
+      })()
+    </script>
+    <script type="text/javascript" defer crossorigin src="${
+      manifest?.[pkgName]
+    }"></script>
+  `
 }
 
 /**

--- a/packages/scroll-to-audio/dev/entry.js
+++ b/packages/scroll-to-audio/dev/entry.js
@@ -1,5 +1,4 @@
-// import Karaoke from '../src/react-components'
-import React from 'react' // eslint-disable-line
+import React, { useRef } from 'react' // eslint-disable-line
 import styled from 'styled-components'
 import { createRoot } from 'react-dom/client'
 import { ScrollToAudio } from '../src/index'
@@ -8,30 +7,154 @@ const reactRootId = 'root'
 const container = document.getElementById(reactRootId)
 const root = createRoot(container)
 
-const MockContentBlock = styled.div`
-  height: 200vh;
-  background-color: pink;
-  margin-bottom: 50px;
-  margin-top: 50px;
+// ── Layout ────────────────────────────────────────────────────────────────────
+
+const PageWrapper = styled.div`
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 24px 120px;
+  font-family: sans-serif;
 `
 
-const EmbedCodeBlock = styled.div`
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 700px;
+const PageTitle = styled.h1`
+  font-size: 20px;
+  color: #333;
+  padding: 32px 0 8px;
+  border-bottom: 2px solid #333;
+  margin-bottom: 48px;
 `
 
-root.render(
-  <div>
-    <ScrollToAudio hintOnly={true} />
-    <MockContentBlock />
-    <EmbedCodeBlock>
-      <ScrollToAudio id="scroll-to-audio-1" audioUrls={['./audio-1.mp3']} />
-    </EmbedCodeBlock>
-    <MockContentBlock />
-    <div id="scroll-to-audio-1-bottom-entry-point" />
-    <ScrollToAudio id="scroll-to-audio-2" audioUrls={['./audio-2.mp3']} />
-    <MockContentBlock />
-    <div id="scroll-to-audio-2-bottom-entry-point" />
-  </div>
-)
+const TestSection = styled.section`
+  margin-bottom: 80px;
+`
+
+const TestTitle = styled.h2`
+  font-size: 16px;
+  font-weight: bold;
+  color: #555;
+  margin-bottom: 6px;
+`
+
+const TestDesc = styled.p`
+  font-size: 14px;
+  color: #888;
+  margin: 0 0 24px;
+`
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const Band = styled.div`
+  height: ${(p) => p.$height || '100vh'};
+  background: ${(p) => p.$bg || '#f0f0f0'};
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #aaa;
+  font-size: 14px;
+  margin-bottom: 8px;
+`
+
+// ── Test 2: custom scroll container ──────────────────────────────────────────
+
+const EditorShell = styled.div`
+  position: relative;
+  height: 70vh;
+  overflow-y: scroll;
+  background: #f8f8f8;
+  border: 2px solid #ccc;
+  border-radius: 8px;
+`
+
+const EditorToolbar = styled.div`
+  position: sticky;
+  top: 0;
+  height: 40px;
+  background: #4a4a4a;
+  color: #fff;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  z-index: 10;
+  border-radius: 6px 6px 0 0;
+`
+
+const EditorContent = styled.div`
+  padding: 0 32px 40px;
+`
+
+function CustomScrollContainerTest() {
+  const scrollerRef = useRef(null)
+
+  return (
+    <EditorShell ref={scrollerRef}>
+      <EditorToolbar>
+        模擬 editor-shell（此 div 為 scroll container）
+      </EditorToolbar>
+      <EditorContent>
+        <Band $height="100vh" $bg="#ececec">
+          ↓ 往下捲動
+        </Band>
+
+        <ScrollToAudio
+          id="scroll-to-audio-custom-scroller"
+          audioUrls={['./audio-1.mp3']}
+          scrollerRef={scrollerRef}
+        />
+
+        <Band $height="150vh" $bg="#e4e4e4">
+          audio 播放區間（mute button 應出現）
+        </Band>
+
+        <div id="scroll-to-audio-custom-scroller-bottom-entry-point" />
+
+        <Band $height="80vh" $bg="#dcdcdc">
+          ↑ 往上捲動可再觸發
+        </Band>
+      </EditorContent>
+    </EditorShell>
+  )
+}
+
+// ── App ───────────────────────────────────────────────────────────────────────
+
+function App() {
+  return (
+    <PageWrapper>
+      <PageTitle>scroll-to-audio</PageTitle>
+
+      {/* Test 1: window scroll */}
+      <TestSection>
+        <TestTitle>綁定在 window 上</TestTitle>
+        <TestDesc>
+          未傳入 scrollerRef，scroll container 預設為 window。滾動頁面，mute
+          button 應出現。
+        </TestDesc>
+        <Band $height="100vh" $bg="#fde8e8">
+          ↓ 往下捲動
+        </Band>
+        <ScrollToAudio id="scroll-to-audio-1" audioUrls={['./audio-1.mp3']} />
+        <Band $height="150vh" $bg="#fdd8d8">
+          audio 播放區間（mute button 應出現）
+        </Band>
+        <div id="scroll-to-audio-1-bottom-entry-point" />
+        <Band $height="80vh" $bg="#fcc8c8">
+          ↑ 往上捲動可再觸發
+        </Band>
+      </TestSection>
+
+      {/* Test 2: custom scroll container */}
+      <TestSection>
+        <TestTitle>綁定在特定 element 上</TestTitle>
+        <TestDesc>
+          透過 scrollerRef 將 scroll container 指定為下方的 div（模擬
+          editor-shell.fullscreen）。在框框內往下捲動，mute button 應出現。
+        </TestDesc>
+        <CustomScrollContainerTest />
+      </TestSection>
+    </PageWrapper>
+  )
+}
+
+root.render(<App />)

--- a/packages/scroll-to-audio/package.json
+++ b/packages/scroll-to-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-scroll-to-audio",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/scroll-to-audio/src/index.tsx
+++ b/packages/scroll-to-audio/src/index.tsx
@@ -18,6 +18,7 @@ function ScrollToAudio({
   preload = 'auto',
   hintOnly = false,
   hintId,
+  scrollerRef,
 }: {
   id: string
   audioUrls: string[]
@@ -26,6 +27,7 @@ function ScrollToAudio({
   bottomEntryOnly?: boolean
   hintOnly?: boolean
   hintId?: string
+  scrollerRef?: React.RefObject<HTMLElement>
 }) {
   const audioRef = useRef<HTMLAudioElement>(null)
   const [muted, setMuted] = hooks.useMuted(true, audioRef)
@@ -45,6 +47,9 @@ function ScrollToAudio({
       return
     }
 
+    const scrollTarget: Window | HTMLElement = scrollerRef?.current ?? window
+    const containerEl = scrollerRef?.current
+
     const handleScroll = _.debounce(() => {
       const topEntryElement = topEntryPointRef.current
       const bottomEntryElement = bottomEntryPointRef.current
@@ -57,13 +62,17 @@ function ScrollToAudio({
         console.log(
           `[react-scroll-to-audio][${id}] \`topEntryElement\` is not available. Remove scroll event listener.`
         )
-        window.removeEventListener('scroll', handleScroll)
+        scrollTarget.removeEventListener('scroll', handleScroll)
         return
       }
 
-      const viewportHeight = window.innerHeight
+      const containerRect = containerEl
+        ? containerEl.getBoundingClientRect()
+        : { top: 0, height: window.innerHeight }
+      const viewportHeight = containerRect.height
       const rootMargin = Math.ceil(viewportHeight * 0.25)
-      const topEntryY = topEntryElement.getBoundingClientRect().y
+      const topEntryY =
+        topEntryElement.getBoundingClientRect().y - containerRect.top
 
       // top entry point is below viewport
       // which means element is outside viewport bottom
@@ -79,7 +88,8 @@ function ScrollToAudio({
       if (!bottomEntryElement) {
         bottomEntryY = topEntryY + viewportHeight
       } else {
-        bottomEntryY = bottomEntryElement.getBoundingClientRect().y
+        bottomEntryY =
+          bottomEntryElement.getBoundingClientRect().y - containerRect.top
       }
 
       // bottom entry point is above viewport top,
@@ -108,15 +118,16 @@ function ScrollToAudio({
     console.log(
       `[react-scroll-to-audio][${id}] add scroll event listener. \`muted\` state is ${muted}`
     )
-    window.addEventListener('scroll', handleScroll)
+    scrollTarget.addEventListener('scroll', handleScroll)
 
     return () => {
       console.log(
         `[react-scroll-to-audio][${id}] useEffect cleanup function. Remove scroll event listener.`
       )
-      window.removeEventListener('scroll', handleScroll)
+      scrollTarget.removeEventListener('scroll', handleScroll)
+      handleScroll.cancel()
     }
-  }, [muted, hintOnly])
+  }, [muted, hintOnly, id, scrollerRef])
 
   // set audio muted attribute according to browser muted state
   useEffect(() => {


### PR DESCRIPTION
  ## Summary

  - Support custom scroll containers for `scroll-to-audio`
  - Update `embed-code-generator` to inject `scrollerRef` for embeds inside `.editor-fullscreen-scroller`
  - Fix fullscreen editor entry-point detection by listening to the editor scroll container instead of always using `window`
  - Preserve normal page behavior with the existing `window` fallback
  - Improve the dev entry page with test cases for both window scrolling and custom container scrolling

  ## Testing

  - Manually verified via the updated `scroll-to-audio` dev page