### PR TITLE
chore: update CMS embed-code-generator dependency

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -19,7 +19,7 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.8.0",
     "@story-telling-reporter/draft-editor": "^2.1.2",
-    "@story-telling-reporter/react-embed-code-generator": "^2.2.16",
+    "@story-telling-reporter/react-embed-code-generator": "^2.2.17",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",
     "@story-telling-reporter/react-scrollable-video": "^3.0.1",
     "@story-telling-reporter/react-three-story-controls": "^2.2.3",

--- a/packages/public-cms/package.json
+++ b/packages/public-cms/package.json
@@ -19,7 +19,7 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.8.0",
     "@story-telling-reporter/draft-editor": "^2.1.2",
-    "@story-telling-reporter/react-embed-code-generator": "^2.2.15",
+    "@story-telling-reporter/react-embed-code-generator": "^2.2.17",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",
     "@story-telling-reporter/react-scrollable-video": "^3.0.1",
     "@story-telling-reporter/react-three-story-controls": "^2.2.3",


### PR DESCRIPTION
### Changes
- update `cms` to use `react-embed-code-generator@^2.2.17`
- update `public-cms` to use `react-embed-code-generator@^2.2.17`


### Related PRs
- https://github.com/lab-reporter/storytelling-monorepo/pull/92