### PR TITLE
chore(ecg): bump embed-code-generator to 2.2.20

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -19,7 +19,7 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.8.0",
     "@story-telling-reporter/draft-editor": "^2.1.2",
-    "@story-telling-reporter/react-embed-code-generator": "^2.2.19",
+    "@story-telling-reporter/react-embed-code-generator": "^2.2.20",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",
     "@story-telling-reporter/react-scrollable-video": "^3.0.1",
     "@story-telling-reporter/react-three-story-controls": "^2.2.3",

--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-telling-reporter/react-embed-code-generator",
-  "version": "2.2.19",
+  "version": "2.2.20",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/public-cms/package.json
+++ b/packages/public-cms/package.json
@@ -19,7 +19,7 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.8.0",
     "@story-telling-reporter/draft-editor": "^2.1.2",
-    "@story-telling-reporter/react-embed-code-generator": "^2.2.19",
+    "@story-telling-reporter/react-embed-code-generator": "^2.2.20",
     "@story-telling-reporter/react-scrollable-image": "^0.3.4",
     "@story-telling-reporter/react-scrollable-video": "^3.0.1",
     "@story-telling-reporter/react-three-story-controls": "^2.2.3",


### PR DESCRIPTION
### Changes
- bump `react-embed-code-generator` from `2.2.19` to `2.2.20`
- update `cms` and `public-cms` to depend on `react-embed-code-generator@^2.2.20`

### Reason
react-embed-code-generator@2.2.18 and react-embed-code-generator@2.2.19 have been deprecated due to broken distribution.