### PR TITLE
feat(public-cms): increase resources upload limit 10

### DIFF
--- a/packages/public-cms/lists/audio.ts
+++ b/packages/public-cms/lists/audio.ts
@@ -13,7 +13,7 @@ import {
   createFileFieldHooks,
 } from './utils/access-control-list'
 
-const limit = 5
+const limit = 10
 const fileFieldHooks = createFileFieldHooks(limit, config.files.storagePath)
 
 const listConfigurations = list({

--- a/packages/public-cms/lists/photo.ts
+++ b/packages/public-cms/lists/photo.ts
@@ -12,7 +12,7 @@ import {
   createdByHooks,
   createImageFieldHooks,
 } from './utils/access-control-list'
-const limit = 5
+const limit = 10
 const imageFieldHooks = createImageFieldHooks(limit, config.images.storagePath)
 
 const listConfigurations = list({

--- a/packages/public-cms/lists/video.ts
+++ b/packages/public-cms/lists/video.ts
@@ -13,7 +13,7 @@ import {
   createFileFieldHooks,
 } from './utils/access-control-list'
 
-const limit = 5
+const limit = 10
 const fileFieldHooks = createFileFieldHooks(limit, config.files.storagePath)
 
 const listConfigurations = list({


### PR DESCRIPTION
 ## Summary

  - Increase public CMS audio, photo, and video upload limits from 5 to 10.
  - Update resource validation limits so students can upload more project assets.

  ## Why

  - Some students emailed us that they need more resources to complete their projects.